### PR TITLE
feat: add option to toggle admin only registration

### DIFF
--- a/auth.tf
+++ b/auth.tf
@@ -8,6 +8,8 @@ module "auth" {
   css_file   = local.auth.css_file
   image_file = local.auth.image_file
 
+  admin_registration_only   = local.auth.admin_registration_only
+
   domain         = local.domain_auth
   hosted_zone_id = one(data.aws_route53_zone.domain[*].zone_id)
 

--- a/auth/cognito.tf
+++ b/auth/cognito.tf
@@ -1,6 +1,11 @@
 resource "aws_cognito_user_pool" "user" {
   name = "${local.prefix}-user"
 
+
+  admin_create_user_config {
+    allow_admin_create_user_only = var.admin_registration_only
+  }
+
   #TODO
   username_attributes      = ["email"]
   auto_verified_attributes = ["email"]

--- a/auth/variables.tf
+++ b/auth/variables.tf
@@ -10,6 +10,10 @@ variable "domain" {
   type = string
 }
 
+variable "admin_registration_only" {
+  type = bool
+}
+
 variable "css_file" {
   type = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -38,6 +38,7 @@ variable "auth" {
   type = object({
     css_file   = optional(string)
     image_file = optional(string)
+    admin_registration_only = optional(bool)
 
     post_authentication_trigger = optional(object({
       source_dir    = string
@@ -240,6 +241,8 @@ locals {
   })
 
   prefix = "fun-${local.module_name}-${var.stage}"
+
+  admin_registration_only = var.auth.admin_registration_only != null ? var.auth.admin_registration_only : false
 
   domain         = var.domain == null ? null : (var.domain.deploy_to_subdomain == null || var.domain.deploy_to_subdomain == "" ? var.domain.name : "${var.domain.deploy_to_subdomain}.${var.domain.name}")
   domain_website = local.domain


### PR DESCRIPTION
Setting this flag enables registration by admin only. It seems to disables the signup in the UI as well.

Signed-off-by: GRBurst <GRBurst@protonmail.com>