### PR TITLE
auth: require base64 encoding for image file

### DIFF
--- a/auth.tf
+++ b/auth.tf
@@ -5,8 +5,8 @@ module "auth" {
   prefix                = local.prefix
   log_retention_in_days = local.logging.retention_in_days
 
-  css_content   = local.auth.css_content
-  image_content = local.auth.image_content
+  css_content           = local.auth.css_content
+  image_base64_content  = local.auth.image_base64_content
 
   admin_registration_only = local.auth.admin_registration_only
 

--- a/auth/cognito.tf
+++ b/auth/cognito.tf
@@ -79,11 +79,11 @@ resource "aws_cognito_user_pool_client" "website_client" {
 }
 
 resource "aws_cognito_user_pool_ui_customization" "hosted_ui" {
-  count     = var.css_content != null || var.image_content != null ? 1 : 0
+  count     = var.css_content != null || var.image_base64_content != null ? 1 : 0
   client_id = aws_cognito_user_pool_client.website_client.id
 
   css        = var.css_content
-  image_file = var.image_content == null ? null : base64(var.image_content)
+  image_file = var.image_base64_content
 
   user_pool_id = aws_cognito_user_pool_domain.user.user_pool_id
 }

--- a/auth/variables.tf
+++ b/auth/variables.tf
@@ -18,7 +18,7 @@ variable "css_content" {
   type = string
 }
 
-variable "image_content" {
+variable "image_base64_content" {
   type = string
 }
 

--- a/tests/maximal.tf
+++ b/tests/maximal.tf
@@ -63,8 +63,8 @@ module "maximal" {
   }
 
   auth = {
-    # image_content = "file(auth.jpg)"
-    # css_content   = "file(auth.css)"
+    # image_base64_content  = "filebase64(auth.jpg)"
+    # css_content           = "file(auth.css)"
   }
 
   dev_setup = {

--- a/variables.tf
+++ b/variables.tf
@@ -38,7 +38,7 @@ variable "auth" {
   description = "auth module with cognito"
   type = object({
     css_content                = optional(string)
-    image_content              = optional(string)
+    image_base64_content       = optional(string)
     admin_registration_only = optional(bool)
 
     post_authentication_trigger = optional(object({


### PR DESCRIPTION
This PR is created for further discussion.

Instead of an image-encoding string, we require the image to be base64 encoded already.
This allows uploading of local files using `filebase64("myfilepath.png")`.
It further simplifies the module since we don't have to test weather it contains data or not.

Signed-off-by: GRBurst <GRBurst@protonmail.com>
